### PR TITLE
Fix LGR RNC schema "reference" production nesting

### DIFF
--- a/lgr-1.0.rnc
+++ b/lgr-1.0.rnc
@@ -403,19 +403,19 @@ meta-section = element meta {
     }?
     & element references {
         element reference {
-            attribute id { 
-             xsd:token {
-              # limit id attribute to uppercase letters, digits 
-              # and a few punctuation marks; use of integers 
-              # is RECOMMENDED
-               pattern = "[\-_.:0-9A-Z]*"
-               minLength = "1"
+            attribute id {
+                xsd:token {
+                    # limit id attribute to uppercase letters, digits 
+                    # and a few punctuation marks; use of integers 
+                    # is RECOMMENDED
+                    pattern = "[\-_.:0-9A-Z]*"
+                    minLength = "1"
+                }
              },
              attribute comment { text }?,
              text
-            }*
-        }?
-    }
+        }*
+    }?
 }
 
 data-section = element data { (char | range)+ }


### PR DESCRIPTION
This fixes a regression from a recent update of the RNC schema, with the `attribute comment` production incorrectly nested under the `attribute id` production in the `reference` element prodution.

This causes an error "Found forbidden pattern attribute//attribute" when the trying to use the schema.
