### PR TITLE
Remove from-tag attributre from class-invocation

### DIFF
--- a/lgr-1.0.rnc
+++ b/lgr-1.0.rnc
@@ -136,12 +136,10 @@ variant = element var {
 
 ## a "class" element that references the name of another "class"
 ## (or set-operator like "union") defined elsewhere.
-## If used as a matcher (appearing under a "rule" ## element),
+## If used as a matcher (appearing under a "rule" element),
 ## the "count" attribute may be present.
 class-invocation = element class {
-    (
-      attribute by-ref { class-ref }
-      | attribute from-tag { tag-ref }),
+    attribute by-ref { class-ref },
     attribute count { count-pattern }?,
     attribute comment { text }?
 }


### PR DESCRIPTION
- The from-tag attribute appears in both the `class-invocation` and `class-declaration` productions. It should only be in the latter, which looks correct in its current form.
